### PR TITLE
Fix artifact action version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Build site
         run: bundle exec jekyll build -d docs
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: site
           path: docs


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4`

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle check` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6844681bf12c832f9fa3b2e5c2cb487d