### PR TITLE
Fix Jekyll paginate dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gem "jekyll", "~> 4.3"
 
 group :jekyll_plugins do
   gem "jekyll-remote-theme"
+  gem "jekyll-paginate"
 end

--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,4 @@ remote_theme: cotes2020/jekyll-theme-chirpy
 
 plugins:
   - jekyll-remote-theme
+  - jekyll-paginate


### PR DESCRIPTION
## Summary
- add `jekyll-paginate` gem
- enable `jekyll-paginate` plugin in `_config.yml`

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 Forbidden)*
- `bundle exec jekyll build -d docs` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_684469730278832f8e7c8a80823ced43